### PR TITLE
Partial Workspace and Language Client Connection API

### DIFF
--- a/src/main/scala/atom/Atom.scala
+++ b/src/main/scala/atom/Atom.scala
@@ -64,6 +64,35 @@ trait TextEditor extends js.Object {
   def getLineCount(): Long = js.native
 }
 
+/** Represents the state of the user interface for the entire window. */
+@js.native
+trait Workspace extends js.Object {
+  // Event Subscription
+  /**
+   *  Invoke the given callback with all current and future text editors in
+   *  the workspace.
+   */
+  def observeTextEditors(callback: TextEditor => Unit): Disposable = js.native
+
+  /**
+   *  Invoke the given callback when a text editor becomes the active text editor and
+   *  when there is no longer an active text editor.
+   */
+  def onDidChangeActiveTextEditor(callback: js.UndefOr[TextEditor] => Unit): Disposable = js.native
+
+  /**
+   *  Invoke the given callback with the current active text editor (if any), with all
+   *  future active text editors, and when there is no longer an active text editor.
+   */
+  def observeActiveTextEditor(callback: js.UndefOr[TextEditor] => Unit): Disposable = js.native
+
+  /** Get all text editors in the workspace. */
+  def getTextEditors(): js.Array[TextEditor] = js.native
+
+  /** Get the workspace center's active item if it is a TextEditor. */
+  def getActiveTextEditor(): js.UndefOr[TextEditor] = js.native
+}
+
 class ConfigOptions (
   val sources: js.UndefOr[js.Array[String]] = js.undefined,
   val excludeSources: js.UndefOr[js.Array[String]] = js.undefined
@@ -131,6 +160,7 @@ object Atom extends js.Object {
   val commands: CommandRegistry = js.native
   val config: Config = js.native
   val notifications: NotificationManager = js.native
+  val workspace: Workspace = js.native
 
   def inDevMode(): Boolean = js.native
   def inSafeMode(): Boolean = js.native

--- a/src/main/scala/atom/languageclient/AutoLanguageClient.scala
+++ b/src/main/scala/atom/languageclient/AutoLanguageClient.scala
@@ -95,4 +95,7 @@ class AutoLanguageClient extends js.Object {
    * @return false => message will not be sent to the language server
    */
   def filterChangeWatchedFiles(filePath: String): Boolean = js.native
+  
+  // Gets a LanguageClientConnection for a given TextEditor
+  def getConnectionForEditor(editor: TextEditor): js.Promise[js.UndefOr[LanguageClientConnection]] = js.native
 }

--- a/src/main/scala/atom/languageclient/LanguageClientConnection.scala
+++ b/src/main/scala/atom/languageclient/LanguageClientConnection.scala
@@ -1,0 +1,24 @@
+package laughedelic.atom.languageclient
+
+import io.scalajs.nodejs.events.EventEmitter
+import scala.scalajs.js
+
+// Public: Parameters to send with a workspace/executeCommand request.
+class ExecuteCommandParams (
+  // The identifier of the actual command handler.
+  val command: String,
+  // Arguments that the command should be invoked with.
+  val arguments: js.UndefOr[js.Array[js.Any]] = js.undefined
+) extends js.Object
+
+@js.native 
+trait LanguageClientConnection extends EventEmitter {
+
+  // Public: Send a `workspace/executeCommand` request.
+  //
+  // * `params` The {ExecuteCommandParams} specifying the command and arguments
+  // the language server should execute (these commands are usually from {CodeLens} or {CodeAction}
+  // responses).
+  // Returns a {Promise} containing anything.
+  def executeCommand(params: ExecuteCommandParams): js.Promise[js.Any] = js.native
+}


### PR DESCRIPTION
Hi @laughedelic!

I was looking how to implement https://github.com/laughedelic/atom-ide-scala/issues/27 and found https://github.com/atom/atom-languageclient/blob/10735d62a8c549b38f7f110681a0c65684618a62/lib/languageclient.js#L358. The only way I found to retrieve the language client is using https://github.com/atom/atom-languageclient/blob/10735d62a8c549b38f7f110681a0c65684618a62/lib/auto-languageclient.js#L196 and it require the TextEditor ref.