### PR TITLE
Improve typed-config API

### DIFF
--- a/src/main/scala/atom/config-schema/ConfigSchema.scala
+++ b/src/main/scala/atom/config-schema/ConfigSchema.scala
@@ -7,13 +7,20 @@ class ConfigSchema extends js.Object { conf: Singleton =>
 
   def init(prefix: String): ConfigSchema = {
     conf.asInstanceOf[js.Dictionary[js.Dynamic]]
-      .foreach { case (key, value) =>
-        val newPrefix = s"${prefix}.${key}"
-        if (value.isInstanceOf[Setting[_]])
-          value.updateDynamic("label")(newPrefix)
-        else if (value.isInstanceOf[SettingsGroup[_]])
-          value.asInstanceOf[SettingsGroup[ConfigSchema]]
-            .properties.init(newPrefix)
+      .filter {
+        case (_, value: js.Object) =>
+          value.hasOwnProperty("type")
+      }
+      .zipWithIndex
+      .foreach {
+        case ((key, value), index) =>
+          value.updateDynamic("order")(index + 1)
+          val newPrefix = s"${prefix}.${key}"
+          if (value.isInstanceOf[Setting[_]])
+            value.updateDynamic("label")(newPrefix)
+          else if (value.isInstanceOf[SettingsGroup[_]])
+            value.asInstanceOf[SettingsGroup[ConfigSchema]]
+              .properties.init(newPrefix)
       }
     conf
   }

--- a/src/main/scala/atom/config-schema/Setting.scala
+++ b/src/main/scala/atom/config-schema/Setting.scala
@@ -13,14 +13,13 @@ class Setting[T](
   val default: T,
   val title:       js.UndefOr[String] = js.undefined,
   val description: js.UndefOr[String] = js.undefined,
-  val order:       js.UndefOr[Int] = js.undefined,
   val enum:        js.UndefOr[js.Array[T] | js.Array[AllowedValue[T]]] = js.undefined,
   val minimum:     js.UndefOr[T] = js.undefined,
   val maximum:     js.UndefOr[T] = js.undefined,
 )(implicit tpe: SettingType[T]) extends js.Object {
 
   final val `type`: String = tpe.name
-
+  final val order: js.UndefOr[Int] = js.undefined
   final val label: js.UndefOr[String] = js.undefined
 
   final val items = tpe.itemsType.map { it =>

--- a/src/main/scala/atom/config-schema/SettingsGroup.scala
+++ b/src/main/scala/atom/config-schema/SettingsGroup.scala
@@ -2,17 +2,15 @@ package laughedelic.atom.config
 
 import scala.scalajs.js
 
-class SettingsGroup[S <: ConfigSchema](
+class SettingsGroup[S <: ConfigSchema](schema: S)(
   val title: js.UndefOr[String] = js.undefined,
-  val description: js.UndefOr[String] = js.undefined,
   val order: js.UndefOr[Int] = js.undefined,
   val collapsed: js.UndefOr[Boolean] = js.undefined,
-  schema: S,
 ) extends js.Object {
 
   final val `type`: String = "object"
 
-  final val properties = schema
+  final val properties: S = schema
 }
 
 object SettingsGroup {

--- a/src/main/scala/atom/config-schema/SettingsGroup.scala
+++ b/src/main/scala/atom/config-schema/SettingsGroup.scala
@@ -2,13 +2,14 @@ package laughedelic.atom.config
 
 import scala.scalajs.js
 
-class SettingsGroup[S <: ConfigSchema](schema: S)(
+class SettingsGroup[S <: ConfigSchema](
+  schema: S,
   val title: js.UndefOr[String] = js.undefined,
-  val order: js.UndefOr[Int] = js.undefined,
   val collapsed: js.UndefOr[Boolean] = js.undefined,
 ) extends js.Object {
 
   final val `type`: String = "object"
+  final val order: js.UndefOr[Int] = js.undefined
 
   final val properties: S = schema
 }


### PR DESCRIPTION
- changed `SettingsGroup` signature (see below)
- removed `order` from the `Setting`s constructor and added it to the config initialization, so now `order` field will be set automatically and correspond to the order setting values are declared in the code 🚀 